### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,11 +43,12 @@ config.local.neon
 ```neon
 tracy:
 	bar:
-	    - jakubenglicky\SmsManager\Diagnostics\Panel(%tempDir%)
+		- jakubenglicky\SmsManager\Diagnostics\Panel(%tempDir%)
 
-smsmanager:
-        class: jakubenglicky\SmsManager\IClient
-        factory: jakubenglicky\SmsManager\Diagnostics\DebugClient(%tempDir%)
+services:
+	smsmanager:
+		class: jakubenglicky\SmsManager\IClient
+		factory: jakubenglicky\SmsManager\Diagnostics\DebugClient(%tempDir%)
 ```
 
 This panel was inspired by the [Nextras Mail Panel](https://github.com/nextras/mail-panel)


### PR DESCRIPTION
I think that the "services" section is missing in the example as the extension has no factory class parameter.