### PR TITLE
Allow the guzzlehttp/guzzle ^7.0 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 
   "require": {
     "php": "^7.1 || ^8.0",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.3 || ^7.0",
     "smartemailing/types": "^1.1",
     "tracy/tracy": "^2.4",
     "latte/latte": "^2.4"


### PR DESCRIPTION
Do you see any problem with allowing ^7.0 versions of the guzzlehttp/guzzle dependency, please?

I've tried it with the 7.4.3 version and (so far) haven't encountered any problem.

Someone already created an [issue #10](https://github.com/jakubenglicky/sms-manager/issues/10).